### PR TITLE
Allow Laravel Scout + Attribute Getters

### DIFF
--- a/src/Http/Controllers/SearchableSelectController.php
+++ b/src/Http/Controllers/SearchableSelectController.php
@@ -15,10 +15,8 @@ class SearchableSelectController extends Controller
 
         if ($searchable && $request->filled('search')) {
             $items = $request->model()::search($request->get('search'));
-            $getArray = [];
         } else {
             $items = $request->toQuery();
-            $getArray = [$request->get("value")];
         }
 
         if ($request->has("use_resource_ids")) {


### PR DESCRIPTION
Utilise Laravel Scout when it is available as well as allowing labels to be derived from getters.