### PR TITLE
Fix relatableQuery often failing if the model is searchable

### DIFF
--- a/src/Http/Controllers/SearchableSelectController.php
+++ b/src/Http/Controllers/SearchableSelectController.php
@@ -32,8 +32,10 @@ class SearchableSelectController extends Controller
         if ($request->has("max")) {
             $items = $items->take($request->get("max"));
         }
-
-        $request->resource()::relatableQuery($request, $items);
+    
+        if (!$searchable) { // Don't apply the relatableQuery if not searchable, it won't handle it
+            $request->resource()::relatableQuery($request, $items);
+        }
 
         $items = $items->get()->makeVisible(['display', 'value'])->each(function ($item) use ($request, $label) {
             $item->display = $item->{$label};


### PR DESCRIPTION
When a model is searchable and we apply the relatable query it will fail. In my application I was then applying a global scope and it caused an exception.

The relatableQuery method expects `Illuminate\Database\Eloquent\Builder` instead of the `Laravel\Scout\Builder` which are incompatible.

To fix it I simply check if it's searchable and if-so to ignore the relatableQuery (What else could we do, I'm not sure).